### PR TITLE
Update TailwindIntegration.targets - added quotation marks

### DIFF
--- a/samples/shared/TailwindIntegration.targets
+++ b/samples/shared/TailwindIntegration.targets
@@ -5,7 +5,7 @@
 
     <Target Name="TailwindBuild" BeforeTargets="CoreBuild" DependsOnTargets="GetTailwindInputs; AcquireTailwindTooling"
             Inputs="@(TailwindFileInputs)" Outputs="$(TailwindCssOutput)">
-        <Exec Command="$(TailwindExePath) -i $(TailwindCssInput) -o $(TailwindCssOutput)" />
+        <Exec Command="&quot;$(TailwindExePath)&quot; -i $(TailwindCssInput) -o $(TailwindCssOutput)" />
         <Touch Files="$(TailwindCssOutput)" />
         <ItemGroup>
             <FileWrites Include="$(TailwindCssOutput)" />


### PR DESCRIPTION
If the full path contains spaces, the command must be enclosed in quotation marks.