### PR TITLE
Correctly pass default or user-defined value of similarity threshold to LocalEmbedder for Smart ComboBox

### DIFF
--- a/samples/ExampleMvcRazorPagesApp/Program.cs
+++ b/samples/ExampleMvcRazorPagesApp/Program.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using Microsoft.Extensions.Primitives;
+using SmartComponents.Inference;
 using SmartComponents.Inference.OpenAI;
 using SmartComponents.LocalEmbeddings;
 
@@ -44,6 +47,19 @@ var expenseCategories = embedder.EmbedRange(
     ["Groceries", "Utilities", "Rent", "Mortgage", "Car Payment", "Car Insurance", "Health Insurance", "Life Insurance", "Home Insurance", "Gas", "Public Transportation", "Dining Out", "Entertainment", "Travel", "Clothing", "Electronics", "Home Improvement", "Gifts", "Charity", "Education", "Childcare", "Pet Care", "Other"]);
 
 app.MapSmartComboBox("/api/suggestions/accounting-categories",
-    request => embedder.FindClosest(request.Query, expenseCategories));
+    request =>
+    {
+        StringValues minSimilarity;
+        request.HttpContext.Request.Form.TryGetValue("similarityThreshold", out minSimilarity);
+
+        var query = new SimilarityQuery()
+        {
+
+            SearchText = request.Query.SearchText,
+            MaxResults = request.Query.MaxResults,
+            MinSimilarity = Convert.ToSingle(minSimilarity.ToString(), new CultureInfo("en-US"))
+        };
+        return embedder.FindClosest(query, expenseCategories);
+    });
 
 app.Run();


### PR DESCRIPTION
Smart ComboBox always posts 5 (integer) as the value of similarity threshold. This prevents the MVC Razor Pages example to work properly (no suggestions are presented). The sample code is (quickly) fixed by getting the POSTed value of `similarityThreshold` parameter and converting it to `float` using the expected format provider.

Addresses #64 for the MVC Razor Pages sample code. #64 still needs to be fixed internally.